### PR TITLE
Fix extra quote in header anchor tag

### DIFF
--- a/_includes/header.liquid
+++ b/_includes/header.liquid
@@ -1,6 +1,6 @@
 <header>
   <h1 class="logo">
-    <a rel="author" href="{{ "/" | relative_url }}" alt="{{ site.title }}"">
+    <a rel="author" href="{{ "/" | relative_url }}" alt="{{ site.title }}">
       <img src="{{ "/assets/images/logo.svg" | relative_url }}" alt="{{ site.title }}">
     </a>
   </h1>


### PR DESCRIPTION
## Summary
- fix stray double-quote in header anchor

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_686c12d2588c8325ac58487e48e06cb2