### PR TITLE
fix: clean up header link attributes

### DIFF
--- a/_includes/header.liquid
+++ b/_includes/header.liquid
@@ -1,6 +1,6 @@
 <header>
   <h1 class="logo">
-    <a rel="author" href="{{ "/" | relative_url }}" alt="{{ site.title }}">
+    <a rel="author" aria-label="{{ site.title }}" href="{{ "/" | relative_url }}">
       <img src="{{ "/assets/images/logo.svg" | relative_url }}" alt="{{ site.title }}">
     </a>
   </h1>


### PR DESCRIPTION
## Summary
- fix header link by using `aria-label` and removing alt

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_686c267708f48325a6952a579f1dee7e