### PR TITLE
Add README for Jekyll site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# ronron.co
+
+This repository contains the source code for **ronron.co**, a simple web site built with [Jekyll](https://jekyllrb.com/).
+
+## Local development
+
+1. Install Bundler if you don't have it:
+   ```bash
+   gem install bundler
+   ```
+2. Install the project dependencies:
+   ```bash
+   bundle install
+   ```
+3. Serve the site locally:
+   ```bash
+   bundle exec jekyll serve
+   ```
+
+The site will be available at `http://localhost:4000` by default.


### PR DESCRIPTION
## Summary
- document that this repo hosts the ronron.co Jekyll site
- show simple steps to install dependencies and serve locally

## Testing
- `bundle install`
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_686c2800e3ac8325be2c32b72c6c789b